### PR TITLE
Bump to 0.35.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TRIVY_IMAGE_TAG ?= 0.33.0
+TRIVY_IMAGE_TAG ?= 0.34.0
 OUTPUT_IMAGE ?= mesosphere/trivy-bundles
 
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TRIVY_IMAGE_TAG ?= 0.34.0
+TRIVY_IMAGE_TAG ?= 0.35.0
 OUTPUT_IMAGE ?= mesosphere/trivy-bundles
 
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TRIVY_IMAGE_TAG ?= 0.32.1
+TRIVY_IMAGE_TAG ?= 0.33.0
 OUTPUT_IMAGE ?= mesosphere/trivy-bundles
 
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )


### PR DESCRIPTION
Relates to :
[Insights: Bump Trivy to v0.33.0 for k8s v1.25.0 Support](https://d2iq.atlassian.net/browse/D2IQ-94913)
[Amoreno/bump trivy to 0.35.0](https://github.com/mesosphere/dkp-insights/pull/555)