### PR TITLE
(CI) fix: consistent timestamp on bundle tags

### DIFF
--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -3,7 +3,6 @@ name: update-bundle-images
 
 on:
   workflow_dispatch:
-  push:
   schedule:
     # at 6  a.m. every Wednesday
     - cron: "0 6 * * 3"

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -19,10 +19,10 @@ jobs:
   determine-if-workflow-should-run:
     runs-on: ubuntu-latest
     outputs:
-      WORKFLOW_SHOULD_RUN: ${{ steps.determine_if_workflow_should_run.outputs.WORKFLOW_SHOULD_RUN }}
+      WORKFLOW_SHOULD_RUN: ${{ steps.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN }}
     steps:
     - name: Check if Workflow Should Run Based on value of WEEK_PARITY
-      id: determine_if_workflow_should_run
+      id: determine-if-workflow-should-run
       run: |
         WORKFLOW_SHOULD_RUN=true
 
@@ -93,7 +93,7 @@ jobs:
     if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
     runs-on: ubuntu-latest
     outputs:
-      UPDATED_TIMESTAMP: ${{ steps.rebuild_and_push_images.outputs.UPDATED_TIMESTAMP }}
+      UPDATED_TIMESTAMP: ${{ steps.rebuild-and-push-images.outputs.UPDATED_TIMESTAMP }}
     steps:
       - name: Clone trivy-bundles Repository
         uses: actions/checkout@v3
@@ -116,7 +116,7 @@ jobs:
           password: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
 
       - name: Rebuild and Push Updated trivy-bundles Images
-        id: rebuild_and_push_images
+        id: rebuild-and-push-images
         run: |
           updated_timestamp=$(date -u +%Y%m%dT%H%M%SZ)
           while read branch_and_tag; do

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -38,13 +38,13 @@ jobs:
 
   obtain-trivy-image-tags:
     needs: [determine-if-workflow-should-run]
+    if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
     runs-on: ubuntu-latest
     env:
       # leave blank if you don't want to rebuild trivy-bundles image for the main branch
       dkp_insights_main_branch_name: "origin/main"
     steps:
       - name: Clone dkp-insights Repository
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/checkout@v3
         with:
           repository: mesosphere/dkp-insights
@@ -53,15 +53,12 @@ jobs:
           token: ${{ secrets.MERGEBOT_TOKEN }}
 
       - name: Create Artifact for trivy-bundles Image Tags
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: mkdir -p artifacts && touch ./artifacts/tags-to-rebuild.txt
 
       - name: Fetch All Branches from dkp-insights Repository
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: git fetch
 
       - name: Obtain trivy-bundles Image Tags for each dkp-insights Release Branch
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: |
           dkp_insights_release_branches=($(git branch -r | grep 'origin/release' | tail -n $TAGS_TO_FETCH))
 
@@ -86,7 +83,6 @@ jobs:
           done
 
       - name: Upload Artifact with trivy-bundles Image Tags
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/upload-artifact@v3
         with:
           name: trivy-tags-to-rebuild
@@ -95,40 +91,36 @@ jobs:
 
   rebuild-trivy-bundles-images:
     needs: [obtain-trivy-image-tags, determine-if-workflow-should-run]
+    if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
     runs-on: ubuntu-latest
     steps:
       - name: Clone trivy-bundles Repository
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/checkout@v3
         with:
           repository: mesosphere/trivy-bundles
           ref: main
       
       - name: Download Artifact with dkp-insights Release Branches and their trivy-bundles Image Tags
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/download-artifact@v3
         with:
           name: trivy-tags-to-rebuild
 
       - name: Create an Artifact for Saving Updated trivy-bundles Image Tags
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: mkdir -p artifacts && touch ./artifacts/updated-trivy-bundles-image-tags.txt
       
       - name: Login to Docker Hub
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_READ_WRITE_USERNAME }}
           password: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
 
       - name: Rebuild and Push Updated trivy-bundles Images
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: |
+          updated_time_stamp=$(date -u +%Y%m%dT%H%M%SZ)
           while read branch_and_tag; do
             dkp_insights_branch=${branch_and_tag%=*}
             trivy_bundles_image_tag=${branch_and_tag##*=}
             trivy_image_version=${trivy_bundles_image_tag%-*}
-            updated_time_stamp=$(date -u +%Y%m%dT%H%M%SZ)
 
             echo "dkp_insights_branch: $dkp_insights_branch"
             echo "trivy_bundles_image_tag: $trivy_bundles_image_tag"
@@ -143,9 +135,9 @@ jobs:
             echo "${dkp_insights_branch}=${trivy_image_version}-${updated_time_stamp}" >> ./artifacts/updated-trivy-bundles-image-tags.txt
 
           done <tags-to-rebuild.txt
+          echo "UPDATED_TIME_STAMP=$updated_time_stamp" >> $GITHUB_OUTPUT
 
       - name: Upload Artifact with dkp-insights Release Branch Names and their Corresponding Updated trivy-bundles Image Tags
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/upload-artifact@v3
         with:
           name: updated-trivy-bundles-image-tags
@@ -154,11 +146,11 @@ jobs:
 
   update-dkp-insights-release-branches:
     needs: [rebuild-trivy-bundles-images, determine-if-workflow-should-run]
+    if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
     runs-on: ubuntu-latest
     steps:
 
       - name: Clone dkp-insights Repository
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/checkout@v3
         with:
           repository: mesosphere/dkp-insights
@@ -168,18 +160,15 @@ jobs:
           token: ${{ secrets.MERGEBOT_TOKEN }}
           
       - name: Fetch All Branches from dkp-insights Repository
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         working-directory: dkp-insights
         run: git fetch
 
       - name: Set Git Global Username and Email
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: |
           git config --global user.email "ci-mergebot@d2iq.com"
           git config --global user.name "d2iq-mergebot"
 
       - name: Download Artifact with dkp-insights Release Branches and their Updated trivy-bundles Image Tags
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         uses: actions/download-artifact@v3
         with:
           name: updated-trivy-bundles-image-tags
@@ -188,7 +177,6 @@ jobs:
         run: mv updated-trivy-bundles-image-tags.txt dkp-insights
       
       - name: Install Hub (wrapper for git for opening PRs)
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         run: sudo apt install hub
       
       - name: Import GPG key
@@ -202,16 +190,15 @@ jobs:
           git_config_global: true
         
       - name: Update trivy-bundles Image Tags in Each dkp-insights Release Branch and Open a Pull Request
-        if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
         working-directory: dkp-insights
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
         run: |
+          updated_time_stamp=needs.rebuild-trivy-bundles-images.outputs.UPDATED_TIME_STAMP
           while read branch_and_tag; do
             dkp_insights_branch=${branch_and_tag%=*}
             trivy_bundles_image_tag=${branch_and_tag##*=}
             trivy_image_version=${trivy_bundles_image_tag%-*}
-            updated_time_stamp=$(date -u +%Y%m%dT%H%M%SZ)
 
             echo "dkp_insights_branch: $dkp_insights_branch"
             echo "trivy_bundles_image_tag: $trivy_bundles_image_tag"

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -93,7 +93,7 @@ jobs:
     if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
     runs-on: ubuntu-latest
     outputs:
-      UPDATED_TIME_STAMP: ${{ steps.rebuild_and_push_images.outputs.UPDATED_TIME_STAMP }}
+      UPDATED_TIMESTAMP: ${{ steps.rebuild_and_push_images.outputs.UPDATED_TIMESTAMP }}
     steps:
       - name: Clone trivy-bundles Repository
         uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
       - name: Rebuild and Push Updated trivy-bundles Images
         id: rebuild_and_push_images
         run: |
-          updated_time_stamp=$(date -u +%Y%m%dT%H%M%SZ)
+          updated_timestamp=$(date -u +%Y%m%dT%H%M%SZ)
           while read branch_and_tag; do
             dkp_insights_branch=${branch_and_tag%=*}
             trivy_bundles_image_tag=${branch_and_tag##*=}
@@ -127,17 +127,17 @@ jobs:
             echo "dkp_insights_branch: $dkp_insights_branch"
             echo "trivy_bundles_image_tag: $trivy_bundles_image_tag"
             echo "trivy_image_version: $trivy_image_version"
-            echo "time_stamp: $updated_time_stamp"
+            echo "time_stamp: $updated_timestamp"
 
             TRIVY_IMAGE_TAG=$trivy_image_version \
-              TIMESTAMP=$updated_time_stamp \
+              TIMESTAMP=$updated_timestamp \
               OUTPUT_IMAGE=$TRIVY_IMAGE_NAME \
               make publish-trivy-bundled-image
             
-            echo "${dkp_insights_branch}=${trivy_image_version}-${updated_time_stamp}" >> ./artifacts/updated-trivy-bundles-image-tags.txt
+            echo "${dkp_insights_branch}=${trivy_image_version}-${updated_timestamp}" >> ./artifacts/updated-trivy-bundles-image-tags.txt
 
           done <tags-to-rebuild.txt
-          echo "UPDATED_TIME_STAMP=$updated_time_stamp" >> $GITHUB_OUTPUT
+          echo "UPDATED_TIMESTAMP=$updated_timestamp" >> $GITHUB_OUTPUT
 
       - name: Upload Artifact with dkp-insights Release Branch Names and their Corresponding Updated trivy-bundles Image Tags
         uses: actions/upload-artifact@v3
@@ -196,7 +196,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
         run: |
-          updated_time_stamp=${{ needs.rebuild-trivy-bundles-images.outputs.UPDATED_TIME_STAMP }}
+          updated_timestamp=${{ needs.rebuild-trivy-bundles-images.outputs.UPDATED_TIMESTAMP }}
           while read branch_and_tag; do
             dkp_insights_branch=${branch_and_tag%=*}
             trivy_bundles_image_tag=${branch_and_tag##*=}
@@ -205,14 +205,14 @@ jobs:
             echo "dkp_insights_branch: $dkp_insights_branch"
             echo "trivy_bundles_image_tag: $trivy_bundles_image_tag"
             echo "trivy_image_version: $trivy_image_version"
-            echo "time_stamp: $updated_time_stamp"
+            echo "time_stamp: $updated_timestamp"
 
             echo "checkout branch"
             dkp_insights_branch_name=$( echo $dkp_insights_branch  | cut -f2- -d/ )
             git checkout -b GHA/update-trivy-bundles-image-in/$dkp_insights_branch_name $dkp_insights_branch
 
             echo "replace image tag name"
-            replace_string=$TRIVY_IMAGE_NAME:$trivy_image_version-$updated_time_stamp
+            replace_string=$TRIVY_IMAGE_NAME:$trivy_image_version-$updated_timestamp
             sed -i "s|$TRIVY_IMAGE_NAME:$trivy_image_version-[0-9]\{8\}T[0-9]\{6\}Z|$replace_string|" ./charts/dkp-insights/values.yaml
 
             echo "commit and push changes"

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -193,7 +193,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
         run: |
-          updated_time_stamp=needs.rebuild-trivy-bundles-images.outputs.UPDATED_TIME_STAMP
+          updated_time_stamp=${{ needs.rebuild-trivy-bundles-images.outputs.UPDATED_TIME_STAMP }}
           while read branch_and_tag; do
             dkp_insights_branch=${branch_and_tag%=*}
             trivy_bundles_image_tag=${branch_and_tag##*=}

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -92,6 +92,8 @@ jobs:
     needs: [obtain-trivy-image-tags, determine-if-workflow-should-run]
     if: needs.determine-if-workflow-should-run.outputs.WORKFLOW_SHOULD_RUN
     runs-on: ubuntu-latest
+    outputs:
+      UPDATED_TIME_STAMP: ${{ steps.rebuild_and_push_images.outputs.UPDATED_TIME_STAMP }}
     steps:
       - name: Clone trivy-bundles Repository
         uses: actions/checkout@v3
@@ -114,6 +116,7 @@ jobs:
           password: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
 
       - name: Rebuild and Push Updated trivy-bundles Images
+        id: rebuild_and_push_images
         run: |
           updated_time_stamp=$(date -u +%Y%m%dT%H%M%SZ)
           while read branch_and_tag; do


### PR DESCRIPTION
# Description
Making sure there's only one consistent timestamp being used in the `rebuild-trivy-bundle` workflow

## Which issue(s) does this PR relate to?
Resolves [D2IQ-96174](https://d2iq.atlassian.net/browse/D2IQ-96174)

## Testing
[This workflow](https://github.com/mesosphere/trivy-bundles/actions/runs/4477546529) succeeded and [raised PRs](https://github.com/mesosphere/dkp-insights/pulls?q=is%3Apr+is%3Aopen+trivy-bundles+image+automatic) on `dkp-insights` to update the `trivy-bundles` tags on branches `main`, `release-v0.4` and `release-v0.3` with tags that exists on [the dockerhub registry](https://hub.docker.com/r/mesosphere/trivy-bundles/tags) - ✅ 

## Trade-offs
N/A

## Screenshots
N/A

## Checklist

- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")

[D2IQ-96174]: https://d2iq.atlassian.net/browse/D2IQ-96174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ