### PR TITLE
feat: Add support for generating airgapped bundles for Trivy.

### DIFF
--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -129,9 +129,8 @@ jobs:
             echo "trivy_image_version: $trivy_image_version"
             echo "time_stamp: $updated_timestamp"
 
-            TRIVY_IMAGE_TAG=$trivy_image_version \
+            TRIVY_VERSION=$trivy_image_version \
               TIMESTAMP=$updated_timestamp \
-              OUTPUT_IMAGE=$TRIVY_IMAGE_NAME \
               make publish-trivy-bundled-image
             
             echo "${dkp_insights_branch}=${trivy_image_version}-${updated_timestamp}" >> ./artifacts/updated-trivy-bundles-image-tags.txt

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,13 @@ dist/
 .env
 .envrc
 
+# ignore all local tools
+.local/
+
 # ignore latest image tag
 latest_image_tag
+images.txt
+tags.txt
+
+# ignore all built airgapped bundles
+trivy-bundles-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ TOOLS_DIR ?= $(ROOT_DIR)/.local/tools
 MINDTHEGAP_BIN = $(TOOLS_DIR)/mindthegap
 
 HOST_ARCH=$(shell uname -m)
-OS=$(shell uname | tr '[:upper:]' '[:lower:]')
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 ifeq ($(HOST_ARCH),amd64)
 ARCH := amd64

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ publish-trivy-bundled-image: latest_image_tag
 latest_image_tag: ## Build an image with specified version and tag
 latest_image_tag:
 	$(call print-target)
-	docker build --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) -t $(IMAGE_NAME) .
+	docker build --platform linux/amd64 --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) -t $(IMAGE_NAME) .
 	echo $(IMAGE_NAME_FULL) > $(IMAGES_FILE)
 	echo $(TAG) > $(TAGS_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ install-mindthegap: $(MINDTHEGAP_BIN)
 
 $(MINDTHEGAP_BIN):
 	mkdir -p $(dir $@)
-	curl -Lf https://github.com/mesosphere/mindthegap/releases/download/$(MINDTHEGAP_VERSION)/mindthegap_$(MINDTHEGAP_VERSION)_$(OS)_$(ARCH).tar.gz | tar -xz -C $(TOOLS_DIR) --wildcards 'mindthegap'
+	curl -Lf https://github.com/mesosphere/mindthegap/releases/download/$(MINDTHEGAP_VERSION)/mindthegap_$(MINDTHEGAP_VERSION)_$(OS)_$(ARCH).tar.gz | tar -xz -C $(TOOLS_DIR) 'mindthegap'
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ TOOLS_DIR ?= $(ROOT_DIR)/.local/tools
 MINDTHEGAP_BIN = $(TOOLS_DIR)/mindthegap
 
 HOST_ARCH=$(shell uname -m)
-HOST_OS=$(shell uname | tr '[:upper:]' '[:lower:]')
+OS=$(shell uname | tr '[:upper:]' '[:lower:]')
 
 ifeq ($(HOST_ARCH),amd64)
 ARCH := amd64
@@ -61,12 +61,6 @@ else ifeq ($(HOST_ARCH),x86_64)
 ARCH := amd64
 else ifeq ($(HOST_ARCH),arm64)
 ARCH := amd64
-endif
-
-ifeq ($(HOST_OS),linux)
-OS := linux
-else ifeq ($(HOST_OS),darwin)
-OS := darwin
 endif
 
 .PHONY: install-mindthegap

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 
 .PHONY: create-airgapped-image-bundle
 create-airgapped-image-bundle: ## Create airgapped image bundle
-create-airgapped-image-bundle: install-mindthegap publish-trivy-bundled-image
+create-airgapped-image-bundle: install-mindthegap latest_image_tag
 	$(call print-target)
 	$(MINDTHEGAP_BIN) create image-bundle --platform linux/amd64 --images-file $(IMAGES_FILE) --output-file $(IMAGE)-`cat $(TAGS_FILE)`.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,87 @@
-TRIVY_IMAGE_TAG ?= 0.42.1
-OUTPUT_IMAGE ?= mesosphere/trivy-bundles
+TRIVY_VERSION ?= 0.42.1
 
+ROOT_DIR = $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )
-OUTPUT_IMAGE_TAG = $(TRIVY_IMAGE_TAG)-$(TIMESTAMP)
 
+REGISTRY ?= docker.io
+REPOSITORY ?= mesosphere
+IMAGE ?= trivy-bundles
+TAG ?= $(TRIVY_VERSION)-$(TIMESTAMP)
+
+IMAGE_NAME = $(REPOSITORY)/$(IMAGE):$(TAG)
+IMAGE_NAME_FULL = $(REGISTRY)/$(IMAGE_NAME)
+
+IMAGE_BUNDLE = $(IMAGE)-$(TAG).tar.gz
+
+IMAGES_FILE ?= $(ROOT_DIR)/images.txt
+TAGS_FILE ?= $(ROOT_DIR)/tags.txt
+
+.DEFAULT_GOAL := help
+
+# Enable ONESHELL for all targets
+.ONESHELL:
+
+.PHONY: clean
+clean: ## Clear all intermedieate files
+clean: 
+	rm $(IMAGES_FILE) $(TAGS_FILE)
+
+.PHONY: create-airgapped-image-bundle
+create-airgapped-image-bundle: ## Create airgapped image bundle
+create-airgapped-image-bundle: install-mindthegap publish-trivy-bundled-image
+	$(call print-target)
+	$(MINDTHEGAP_BIN) create image-bundle --platform linux/amd64 --images-file $(IMAGES_FILE) --output-file $(IMAGE)-`cat $(TAGS_FILE)`.tar.gz
+
+.PHONY: publish-trivy-bundled-image
+publish-trivy-bundled-image: ## Publish image to registry
 publish-trivy-bundled-image: latest_image_tag
-	docker push `cat latest_image_tag`
+	$(call print-target)
+	docker push `cat $(IMAGES_FILE)`
 
 .PHONY: latest_image_tag
+latest_image_tag: ## Build an image with specified version and tag
 latest_image_tag:
-	docker build --build-arg TRIVY_IMAGE_TAG=$(TRIVY_IMAGE_TAG) --build-arg TIMESTAMP=$(TIMESTAMP) -t $(OUTPUT_IMAGE):$(OUTPUT_IMAGE_TAG) .
-	echo $(OUTPUT_IMAGE):$(OUTPUT_IMAGE_TAG) > latest_image_tag
+	$(call print-target)
+	docker build --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) -t $(IMAGE_NAME) .
+	echo $(IMAGE_NAME_FULL) > $(IMAGES_FILE)
+	echo $(TAG) > $(TAGS_FILE)
+
+# Tooling needed for mindthegap
+MINDTHEGAP_VERSION ?= v1.11.0
+TOOLS_DIR ?= $(ROOT_DIR)/.local/tools
+
+MINDTHEGAP_BIN = $(TOOLS_DIR)/mindthegap
+
+HOST_ARCH=$(shell uname -m)
+HOST_OS=$(shell uname | tr '[:upper:]' '[:lower:]')
+
+ifeq ($(HOST_ARCH),amd64)
+ARCH := amd64
+else ifeq ($(HOST_ARCH),x86_64)
+ARCH := amd64
+else ifeq ($(HOST_ARCH),arm64)
+ARCH := amd64
+endif
+
+ifeq ($(HOST_OS),linux)
+OS := linux
+else ifeq ($(HOST_OS),darwin)
+OS := darwin
+endif
+
+.PHONY: install-mindthegap
+install-mindthegap: ## Install mind-the-gap binary.
+install-mindthegap: $(MINDTHEGAP_BIN)
+	$(call print-target)
+
+$(MINDTHEGAP_BIN):
+	mkdir -p $(dir $@)
+	curl -Lf https://github.com/mesosphere/mindthegap/releases/download/$(MINDTHEGAP_VERSION)/mindthegap_$(MINDTHEGAP_VERSION)_$(OS)_$(ARCH).tar.gz | tar -xz -C $(TOOLS_DIR) --wildcards 'mindthegap'
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":"}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' | sort
+
+define print-target
+		@printf "Executing target: \033[36m$@\033[0m\n"
+endef

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,23 @@ TAGS_FILE ?= $(ROOT_DIR)/tags.txt
 
 .DEFAULT_GOAL := help
 
+# Tooling needed for mindthegap
+MINDTHEGAP_VERSION ?= v1.11.0
+TOOLS_DIR ?= $(ROOT_DIR)/.local/tools
+
+MINDTHEGAP_BIN = $(TOOLS_DIR)/mindthegap
+
+HOST_ARCH=$(shell uname -m)
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+
+ifeq ($(HOST_ARCH),amd64)
+ARCH := amd64
+else ifeq ($(HOST_ARCH),x86_64)
+ARCH := amd64
+else ifeq ($(HOST_ARCH),arm64)
+ARCH := amd64
+endif
+
 # Enable ONESHELL for all targets
 .ONESHELL:
 
@@ -45,23 +62,6 @@ latest_image_tag:
 	docker build --platform linux/amd64 --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) -t $(IMAGE_NAME) .
 	echo $(IMAGE_NAME_FULL) > $(IMAGES_FILE)
 	echo $(TAG) > $(TAGS_FILE)
-
-# Tooling needed for mindthegap
-MINDTHEGAP_VERSION ?= v1.11.0
-TOOLS_DIR ?= $(ROOT_DIR)/.local/tools
-
-MINDTHEGAP_BIN = $(TOOLS_DIR)/mindthegap
-
-HOST_ARCH=$(shell uname -m)
-OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
-
-ifeq ($(HOST_ARCH),amd64)
-ARCH := amd64
-else ifeq ($(HOST_ARCH),x86_64)
-ARCH := amd64
-else ifeq ($(HOST_ARCH),arm64)
-ARCH := amd64
-endif
 
 .PHONY: install-mindthegap
 install-mindthegap: ## Install mind-the-gap binary.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Trivy Bundles
 
 This repository creates a bundled Aquasec Trivy image with a timestamped database.
+
+This repository mainly uses Makefile targets to perform the required actions.
+Run `make help` to discover all of them.
+
+### Generate a Docker Image with the latest database version.
+Run `make latest_image_tag`
+
+### Publish Docker image to DockerHub
+Run `make publish-trivy-bundled-image`
+
+### Create an airgapped bundle
+Run `make create-airgapped-image-bundle`
+
+### Delete intermediate files
+Run `make clean`


### PR DESCRIPTION
<!-- PR Checklist -->

Add support for generating [mindthegap](https://github.com/mesosphere/mindthegap) based air-gapped bundles for Trivy.

This new build target here `create-airgapped-image-bundle` is referenced in the user-facing docs for [Trivy DB ](https://d2iq.atlassian.net/wiki/spaces/DINS/pages/143327334/Trivy#Verify-the-Trivy-Database-Version)Updates.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
JIRA: https://d2iq.atlassian.net/browse/D2IQ-98692

## Testing

1. Testing of airgapped bundle done by running `make create-airgapped-image-bundle` and inspecting the bundle created by `mindthegap`.
2. Verified that the automated image bump GHA is still functional by issuing a manual run [here](https://github.com/mesosphere/trivy-bundles/actions/runs/6124570487). The following PRs were created as expected in `dkp-insights`: [#1199](https://github.com/mesosphere/dkp-insights/pull/1199), [#1198](https://github.com/mesosphere/dkp-insights/pull/1198), [#1197](https://github.com/mesosphere/dkp-insights/pull/1197), [#1196](https://github.com/mesosphere/dkp-insights/pull/1196).

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [x] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
