### PR TITLE
Bump TRIVY_VERSION to 0.45.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TRIVY_VERSION ?= 0.42.1
+TRIVY_VERSION ?= 0.45.1
 
 ROOT_DIR = $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )


### PR DESCRIPTION
# Description
In order to fix [CVE-2022-48174](https://avd.aquasec.com/nvd/2022/cve-2022-48174/) that is present in the trivy-bundles image that we currently use, we bump the `trivy` base image version of the `trivy-bundles` image to `0.45.1`

## Which issue(s) does this PR relate to?
Resolves [D2IQ-99208](https://d2iq.atlassian.net/browse/D2IQ-99208)

## Testing
- Image built and pushed as expected
- Image checked for critical CVEs and there's 0

## Trade-offs
N/A

## Screenshots
N/A

## Checklist

- [X] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")


[D2IQ-99208]: https://d2iq.atlassian.net/browse/D2IQ-99208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ