### PR TITLE
fix: Disable checkout of submodules in GHA update job.

### DIFF
--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -156,7 +156,7 @@ jobs:
         with:
           repository: mesosphere/dkp-insights
           ref: main
-          submodules: 'true'
+          submodules: 'false'
           path: dkp-insights
           token: ${{ secrets.MERGEBOT_TOKEN }}
           


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

`dkp-insights` uses submodules which change between releases. 
This can complicate the workflow for the [rebuild-trivy-bundle](https://github.com/mesosphere/trivy-bundles/blob/main/.github/workflows/rebuild-trivy-bundle.yaml) GHA.

An example of this failure can be seen [here](https://github.com/mesosphere/trivy-bundles/actions/runs/6556854566/job/17807530776).

In this PR we deliberately disable the checkout of submodules which aren't needed for creating a PR with the updated trivy version. This fixes the failures seen.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

Ran a manual workflow run [here](https://github.com/mesosphere/trivy-bundles/actions/runs/6569170494).
Resulting PRs were created under `dkp-insights` as expected:
- [main](https://github.com/mesosphere/dkp-insights/pull/1292)
- [release-v0.6](https://github.com/mesosphere/dkp-insights/pull/1291)
- [release-v0.5](https://github.com/mesosphere/dkp-insights/pull/1290)
- [release-v0.4](https://github.com/mesosphere/dkp-insights/pull/1289)


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
