### PR TITLE
fix: use busybox as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
+ARG DISTROLESS_NON_ROOT_IMG
 ARG TRIVY_IMAGE_TAG
-FROM aquasec/trivy:${TRIVY_IMAGE_TAG}
 
+FROM aquasec/trivy:${TRIVY_IMAGE_TAG} as build
 WORKDIR /
 RUN mkdir /trivy_cache
 RUN chown 65532:65532 /trivy_cache
@@ -8,11 +9,22 @@ RUN chown 65532:65532 /trivy_cache
 # Run as nonroot user using numeric ID for compatibllity.
 USER 65532
 
+# Download db and cache it.
+RUN trivy image --download-db-only --cache-dir /trivy_cache
+RUN ls -Rl /trivy_cache
+
+# Prepare distroless image for release.
+FROM ${DISTROLESS_NON_ROOT_IMG}
+
+COPY --from=build --chown=nonroot:nonroot /trivy_cache /trivy_cache
+COPY --from=build --chown=nonroot:nonroot /contrib /contrib
+COPY --from=build --chown=nonroot:nonroot /usr/local/bin/trivy /usr/bin/trivy
+
+USER nonroot
+WORKDIR /
+
 # echo ${TIMESTAMP} prevents docker from using cache when a new value of TIMESTAMP is provided
 ARG TIMESTAMP
 RUN echo ${TIMESTAMP}
-
-RUN trivy image --download-db-only --cache-dir /trivy_cache
-RUN ls -Rl /trivy_cache
 
 ENTRYPOINT ["trivy"]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ IMAGE_BUNDLE = $(IMAGE)-$(TAG).tar.gz
 IMAGES_FILE ?= $(ROOT_DIR)/images.txt
 TAGS_FILE ?= $(ROOT_DIR)/tags.txt
 
+DISTROLESS_NON_ROOT_IMG ?= cgr.dev/chainguard/busybox:latest@sha256:6f61c4e219fe99c894ad50d65c40c7b1f3cc7c241ed56c5e19b7df8c94c9affc
+
 .DEFAULT_GOAL := help
 
 # Tooling needed for mindthegap
@@ -59,7 +61,7 @@ publish-trivy-bundled-image: latest_image_tag
 latest_image_tag: ## Build an image with specified version and tag
 latest_image_tag:
 	$(call print-target)
-	docker build --platform linux/amd64 --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) -t $(IMAGE_NAME) .
+	docker build --platform linux/amd64 --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) --build-arg DISTROLESS_NON_ROOT_IMG=$(DISTROLESS_NON_ROOT_IMG) -t $(IMAGE_NAME) .
 	echo $(IMAGE_NAME_FULL) > $(IMAGES_FILE)
 	echo $(TAG) > $(TAGS_FILE)
 


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Fix libcurl [CVE-2023-38545](https://avd.aquasec.com/nvd/cve-2023-38545) by updating the base image.
We cannot use a `static` image a Insight's trivy invokes a [shell command](https://github.com/mesosphere/dkp-insights/blob/main/charts/dkp-insights/templates/trivy/cronjob.yaml#L93-L113) for setup.



## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

Airgapped support verified by [short-circuiting the airgapped verification flag](https://github.com/mesosphere/dkp-insights/blob/main/charts/dkp-insights/templates/trivy/cronjob.yaml#L96-L103) and verifying that the database download is skipped.

Image `docker.io/kaiwalyarjoshi/trivy-bundles:0.45.1-20231221T221336Z` can be used for further verification.

<!--
How can the changes be tested? Is anything required to be able to test (e.g. specific cluster, service definitions)?
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
