### PR TITLE
fix: Fix branch name of Trivy Bundles Update PRs

### DIFF
--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -223,6 +223,6 @@ jobs:
             hub pull-request -m "trivy-bundles image automatic update $(date -u +%Y-%m-%d)" \
               --no-edit \
               --base $dkp_insights_branch_name \
-              --labels "ok-to-test","ready for review"
+              --labels "ready for review"
 
           done <updated-trivy-bundles-image-tags.txt

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -223,6 +223,6 @@ jobs:
             hub pull-request -m "trivy-bundles image automatic update $(date -u +%Y-%m-%d)" \
               --no-edit \
               --base $dkp_insights_branch_name \
-              --labels "ready for review"
+              --labels "ok-to-test","ready for review"
 
           done <updated-trivy-bundles-image-tags.txt

--- a/.github/workflows/rebuild-trivy-bundle.yaml
+++ b/.github/workflows/rebuild-trivy-bundle.yaml
@@ -208,7 +208,7 @@ jobs:
 
             echo "checkout branch"
             dkp_insights_branch_name=$( echo $dkp_insights_branch  | cut -f2- -d/ )
-            git checkout -b GHA/update-trivy-bundles-image-in/$dkp_insights_branch_name $dkp_insights_branch
+            git checkout -b gha-trivy-bundles-update/$dkp_insights_branch_name/$trivy_bundles_image_tag $dkp_insights_branch
 
             echo "replace image tag name"
             replace_string=$TRIVY_IMAGE_NAME:$trivy_image_version-$updated_timestamp
@@ -217,7 +217,7 @@ jobs:
             echo "commit and push changes"
             git add ./charts/dkp-insights/values.yaml
             git commit -m "Updating trivy-bundles image on $(date -u +%Y-%m-%d)"
-            git push origin GHA/update-trivy-bundles-image-in/$dkp_insights_branch_name
+            git push origin gha-trivy-bundles-update/$dkp_insights_branch_name/$trivy_bundles_image_tag
 
             echo "open a pull request"
             hub pull-request -m "trivy-bundles image automatic update $(date -u +%Y-%m-%d)" \


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

This is a long dormant bug. 

When the PRs for `trivy-bundle` updates aren't merged in the dkp-insights repo, we endup with cases where a previously created branch exists and newer scheduled GHA update pushes all [get rejected](https://github.com/mesosphere/trivy-bundles/actions/runs/7271618111/job/19812494567).

Currently, we use a fixed naming scheme to create these updates in the `dkp-insights` repo such as:
- [`GHA/update-trivy-bundles-image-in/release-v0.4`](https://github.com/mesosphere/dkp-insights/pull/1344)
- [`GHA/update-trivy-bundles-image-in/release-v0.5`](https://github.com/mesosphere/dkp-insights/pull/1290)

This PR changes this naming scheme to the following:
- `gha-trivy-bundles-update/<release-branch>/<trivy-version>-<timestamp>`

Here are a few examples:
- [gha-trivy-bundles-update/release-v0.4/0.35.0-20231227T184924Z](https://github.com/mesosphere/dkp-insights/pull/1382)
- [gha-trivy-bundles-update/release-v0.5/0.42.1-20231227T184924Z](https://github.com/mesosphere/dkp-insights/pull/1383)
- [gha-trivy-bundles-update/release-v1.0/0.45.1-20231227T184924Z](https://github.com/mesosphere/dkp-insights/pull/1384)
- [gha-trivy-bundles-update/main/0.45.1-20231227T184924Z](https://github.com/mesosphere/dkp-insights/pull/1385)

With this fix, we should see new PRs created for trivy-bundles irregardless of whether the previous PRs have been merged.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

Test PRs created and linked above.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
