### PR TITLE
fix: Update to Trivy 0.53.0. Require pushing to registry before generating airgapped bundles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TRIVY_VERSION ?= 0.45.1
+TRIVY_VERSION ?= 0.53.0
 
 ROOT_DIR := $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-TRIVY_VERSION ?= 0.53.0
+ifeq ($(origin TRIVY_VERSION), undefined)
+$(error Required env-var TRIVY_VERSION has not been set, please set TRIVY_VERSION to the version matching the NKP/DKP release. See README for details)	
+endif 
 
 ROOT_DIR := $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TRIVY_VERSION ?= 0.45.1
 
-ROOT_DIR = $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR := $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ )
 
 REGISTRY ?= docker.io
@@ -8,10 +8,10 @@ REPOSITORY ?= mesosphere
 IMAGE ?= trivy-bundles
 TAG ?= $(TRIVY_VERSION)-$(TIMESTAMP)
 
-IMAGE_NAME = $(REPOSITORY)/$(IMAGE):$(TAG)
-IMAGE_NAME_FULL = $(REGISTRY)/$(IMAGE_NAME)
+IMAGE_NAME := $(REPOSITORY)/$(IMAGE):$(TAG)
+IMAGE_NAME_FULL := $(REGISTRY)/$(IMAGE_NAME)
 
-IMAGE_BUNDLE = $(IMAGE)-$(TAG).tar.gz
+IMAGE_BUNDLE := $(IMAGE)-$(TAG).tar.gz
 
 IMAGES_FILE ?= $(ROOT_DIR)/images.txt
 TAGS_FILE ?= $(ROOT_DIR)/tags.txt
@@ -21,7 +21,7 @@ DISTROLESS_NON_ROOT_IMG ?= cgr.dev/chainguard/busybox:latest@sha256:6f61c4e219fe
 .DEFAULT_GOAL := help
 
 # Tooling needed for mindthegap
-MINDTHEGAP_VERSION ?= v1.11.0
+MINDTHEGAP_VERSION ?= v1.16.0
 TOOLS_DIR ?= $(ROOT_DIR)/.local/tools
 
 MINDTHEGAP_BIN = $(TOOLS_DIR)/mindthegap
@@ -47,7 +47,7 @@ clean:
 
 .PHONY: create-airgapped-image-bundle
 create-airgapped-image-bundle: ## Create airgapped image bundle
-create-airgapped-image-bundle: install-mindthegap latest_image_tag
+create-airgapped-image-bundle: install-mindthegap publish-trivy-bundled-image
 	$(call print-target)
 	$(MINDTHEGAP_BIN) create image-bundle --platform linux/amd64 --images-file $(IMAGES_FILE) --output-file $(IMAGE)-`cat $(TAGS_FILE)`.tar.gz
 
@@ -61,7 +61,7 @@ publish-trivy-bundled-image: latest_image_tag
 latest_image_tag: ## Build an image with specified version and tag
 latest_image_tag:
 	$(call print-target)
-	docker build --platform linux/amd64 --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) --build-arg DISTROLESS_NON_ROOT_IMG=$(DISTROLESS_NON_ROOT_IMG) -t $(IMAGE_NAME) .
+	docker build --platform linux/amd64 --build-arg TRIVY_IMAGE_TAG=$(TRIVY_VERSION) --build-arg TIMESTAMP=$(TIMESTAMP) --build-arg DISTROLESS_NON_ROOT_IMG=$(DISTROLESS_NON_ROOT_IMG) -t $(IMAGE_NAME_FULL) .
 	echo $(IMAGE_NAME_FULL) > $(IMAGES_FILE)
 	echo $(TAG) > $(TAGS_FILE)
 

--- a/README.md
+++ b/README.md
@@ -5,23 +5,40 @@ This repository creates a bundled Aquasec Trivy image with a timestamped databas
 This repository mainly uses Makefile targets to perform the required actions.
 Run `make help` to discover all of them.
 
-### Override Registry and Repository
+## Set the matching Trivy Version
+
+|DKP/NKP Version |Trivy Version|
+|-|-|
+|NKP 2.12.x|0.53.0|
+|DKP 2.8.x|0.49.1|
+|DKP 2.7.x|0.45.1|
+|DKP 2.6.x|0.42.1|
+
+```bash
+export TRIVY_VERSION=<version matching Insights Release above>
+```
+
+## Override Registry and Repository
 
 Override the default registry and repository values, by setting the following env-vars:
 
-```
+```bash
 export REGISTRY=docker.io
 export REPOSITORY=foo-org
 ```
 
-### Create an airgapped bundle
+## Create an airgapped bundle
+
 Run `make create-airgapped-image-bundle`
 
-### Generate a Docker Image with the latest database version.
+## Generate a Docker Image with the latest database version
+
 Run `make latest_image_tag`
 
-### Publish Docker image to Registry
+## Publish Docker image to Registry
+
 Run `make publish-trivy-bundled-image`
 
-### Delete intermediate files
+## Delete intermediate files
+
 Run `make clean`

--- a/README.md
+++ b/README.md
@@ -5,14 +5,23 @@ This repository creates a bundled Aquasec Trivy image with a timestamped databas
 This repository mainly uses Makefile targets to perform the required actions.
 Run `make help` to discover all of them.
 
-### Generate a Docker Image with the latest database version.
-Run `make latest_image_tag`
+### Override Registry and Repository
 
-### Publish Docker image to DockerHub
-Run `make publish-trivy-bundled-image`
+Override the default registry and repository values, by setting the following env-vars:
+
+```
+export REGISTRY=docker.io
+export REPOSITORY=foo-org
+```
 
 ### Create an airgapped bundle
 Run `make create-airgapped-image-bundle`
+
+### Generate a Docker Image with the latest database version.
+Run `make latest_image_tag`
+
+### Publish Docker image to Registry
+Run `make publish-trivy-bundled-image`
 
 ### Delete intermediate files
 Run `make clean`


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

This PR addresses the following:
- Require a push to the registry before `mindthegap` is invoked, as it pulls from the registry and doesn't check the local image cache.
- Update documentation for end users who might need to override the `REPOSITORY` and `REGISTRY`
- Update mindthegap to the latest version
- Update trivy to the latest shipped version

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

Request in [Slack](https://nutanix.slack.com/archives/C068HGFS19B/p1728643849649369) where an end-user was having difficulty generating an airgapped bundle.

## Testing

- `make create-airgapped-image-bundle`

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
